### PR TITLE
fixing bug, that lead to dismissing receiver msgs

### DIFF
--- a/chromehellotext.html
+++ b/chromehellotext.html
@@ -101,10 +101,9 @@ function onStopAppSuccess() {
  * session listener during initialization
  */
 function sessionListener(e) {
-  appendMessage('New session ID:' + e.sessionId);
+  appendMessage('Existing session ID:' + e.sessionId);
   session = e;
-  session.addUpdateListener(sessionUpdateListener);  
-  session.addMessageListener(namespace, receiverMessage);
+	prepareListeners(session);
 }
 
 /**
@@ -159,9 +158,18 @@ function sendMessage(message) {
   else {
     chrome.cast.requestSession(function(e) {
         session = e;
+				prepareListeners(session);
         session.sendMessage(namespace, message, onSuccess.bind(this, "Message sent: " + message), onError);
       }, onError);
   }
+}
+/**
+ * add listeners to session. Both for existing
+ * and a new session.
+ */
+function prepareListeners(s){
+  s.addUpdateListener(sessionUpdateListener);  
+  s.addMessageListener(namespace, receiverMessage);
 }
 
 /**


### PR DESCRIPTION
Only an existing session was able to receive messages from a receiver
device and likewise session-updates weren’t delivered. This fix
provides both new and existing sessions with the two listeners.