### PR TITLE
call `sessionListener` when requestiong session

### DIFF
--- a/chromehellotext.html
+++ b/chromehellotext.html
@@ -158,7 +158,7 @@ function sendMessage(message) {
   }
   else {
     chrome.cast.requestSession(function(e) {
-        session = e;
+        sessionListener(e);
         session.sendMessage(namespace, message, onSuccess.bind(this, "Message sent: " + message), onError);
       }, onError);
   }


### PR DESCRIPTION
request session takes a callback which sets the session locally, however requesting a session never calls the callbacks set in `sessionListener` which maintain the state of our session info.  It is therefore necessary to call `sessionListener` here explicitly in order to make sure the housekeeping gets done when requesting a session.